### PR TITLE
Adds .scss and .sass files support

### DIFF
--- a/packages/codesandboxer-fs/src/loadRelativeFile.js
+++ b/packages/codesandboxer-fs/src/loadRelativeFile.js
@@ -71,6 +71,8 @@ async function loadRelativeFile(
       return loadImages(resolvedPath, rootDir);
     case '.json':
     case '.css':
+    case '.scss':
+    case '.sass':
       return loadRaw(resolvedPath, rootDir);
     case '.js':
       return loadJS(resolvedPath, pkgJSON, rootDir);


### PR DESCRIPTION
This would throw large stacktraces when using css modules in https://github.com/pedronauck/docz.